### PR TITLE
Fixed __aiter__ to not be awaitable for python>=3.5.2

### DIFF
--- a/aioodbc/cursor.py
+++ b/aioodbc/cursor.py
@@ -299,10 +299,10 @@ class Cursor:
         return fut
 
     if PY_352:
-        async def __aiter__(self):
+        def __aiter__(self):
             return self
     else:
-        def __aiter__(self):
+        async def __aiter__(self):
             return self
 
     async def __anext__(self):


### PR DESCRIPTION
PEP 492 states that for Python 3.5.2 and later __aiter__ should not be async and just return the iterator directly.