### PR TITLE
Add optional pool connections recycling

### DIFF
--- a/aioodbc/connection.py
+++ b/aioodbc/connection.py
@@ -60,6 +60,7 @@ class Connection:
         self._conn = None
 
         self._timeout = timeout
+        self._last_usage = self._loop.time()
         self._autocommit = autocommit
         self._ansi = ansi
         self._dsn = dsn
@@ -105,11 +106,16 @@ class Connection:
         return self._conn.timeout
 
     @property
+    def last_usage(self):
+        return self._last_usage
+
+    @property
     def echo(self):
         return self._echo
 
     async def _cursor(self):
         c = await self._execute(self._conn.cursor)
+        self._last_usage = self._loop.time()
         connection = self
         return Cursor(c, connection)
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -241,6 +241,24 @@ async def test_connect_from_acquire(loop, pool_maker, dsn):
 
 
 @pytest.mark.asyncio
+async def test_pool_with_connection_recycling(loop, pool_maker, dsn):
+    pool = await pool_maker(loop,
+                            dsn=dsn,
+                            minsize=1,
+                            maxsize=1,
+                            pool_recycle=3)
+    async with pool.acquire() as conn:
+        conn1 = conn
+
+    await asyncio.sleep(5, loop=loop)
+
+    assert 1 == pool.freesize
+    async with pool.acquire() as conn:
+        conn2 = conn
+
+    assert conn1 is not conn2
+
+@pytest.mark.asyncio
 async def test_concurrency(loop, pool_maker, dsn):
     pool = await pool_maker(loop, dsn=dsn, minsize=2, maxsize=4)
 


### PR DESCRIPTION
This basically copies what was done in aio-libs/aiopg/pull/373, the biggest difference being the test. 

It's not clear to me how the test in `aiopg` was testing that the connection is actually being recycled. The test in this PR fails without the recycling logic, and passes with it. If I'm mistaken and the logic from the `aiopg` test is necessary please tell me and I'll add it here too. 

Should I add a small note indicating this feature in the documentation somewhere?

Thanks