### PR TITLE
Added basic documentation for after_created and ThreadPoolExecutor.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Contents:
    :maxdepth: 2
 
    examples
+   tuning
    glossary
    contributing
 

--- a/docs/tuning.rst
+++ b/docs/tuning.rst
@@ -1,0 +1,24 @@
+.. _tuning:
+
+
+********
+Configuration Tuning
+********
+
+
+   after_created
+
+      When calling ``aioodbc.connect`` it is possible to pass an async
+      unary function as a parameter for ``after_created``. This allows
+      you to configure additional attributes on the underlying
+      pyodbc connection such as ``.setencoding`` or ``.setdecoding``.
+
+   TheadPoolExecutor
+
+       When using ``aoiodbc.create_pool`` it is considered a
+       good practice to use ``ThreadPoolExecutor`` from
+       ``concurrent.futures`` to create worker threads that
+       are dedicated for database work allowing default threads
+       to do other work and prevent competition between database
+       and default workers.
+


### PR DESCRIPTION
Per gitter conversation wanted to add some basic documentation around `after_created` and `ThreadPoolExecutor`. Once I have the test suite running I will add a related example.