### PR TITLE
added setter for autocommit

### DIFF
--- a/aioodbc/connection.py
+++ b/aioodbc/connection.py
@@ -109,6 +109,10 @@ class Connection:
         """
         return self._conn.autocommit
 
+    @autocommit.setter
+    def autocommit(self, value):
+        self._conn.autocommit = value
+
     @property
     def timeout(self):
         return self._conn.timeout

--- a/aioodbc/cursor.py
+++ b/aioodbc/cursor.py
@@ -52,6 +52,10 @@ class Cursor:
         """
         return self._conn.autocommit
 
+    @autocommit.setter
+    def autocommit(self, value):
+        self._conn.autocommit = value
+
     @property
     def rowcount(self):
         """The number of rows modified by the previous DDL statement.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It can change the `autocommit` state of the connection while it is open.

## Are there changes in behavior for the user?
No

## Related issue number

#269 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
