### PR TITLE
Connection pool is incompatible with Python 3.9 issue fix

### DIFF
--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -25,7 +25,7 @@ async def _create_pool(minsize=10, maxsize=10, echo=False, loop=None,
     pool = Pool(minsize=minsize, maxsize=maxsize, echo=echo, loop=loop,
                 pool_recycle=pool_recycle, **kwargs)
     if minsize > 0:
-        with (await pool._cond):
+        async with pool._cond:
             await pool._fill_free_pool(False)
     return pool
 
@@ -76,7 +76,7 @@ class Pool(asyncio.AbstractServer):
 
     async def clear(self):
         """Close all free connections in pool."""
-        with (await self._cond):
+        async with self._cond:
             while self._free:
                 conn = self._free.popleft()
                 await conn.close()
@@ -105,7 +105,7 @@ class Pool(asyncio.AbstractServer):
             conn = self._free.popleft()
             await conn.close()
 
-        with (await self._cond):
+        async with self._cond:
             while self.size > self.freesize:
                 await self._cond.wait()
 
@@ -119,7 +119,7 @@ class Pool(asyncio.AbstractServer):
     async def _acquire(self):
         if self._closing:
             raise RuntimeError("Cannot acquire connection after closing pool")
-        with (await self._cond):
+        async with self._cond:
             while True:
                 await self._fill_free_pool(True)
                 if self._free:
@@ -168,7 +168,7 @@ class Pool(asyncio.AbstractServer):
                 self._acquiring -= 1
 
     async def _wakeup(self):
-        with (await self._cond):
+        async with self._cond:
             self._cond.notify()
 
     async def release(self, conn):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The await with keyword is no longer supported in python and has been replaced with async keyword. This release fixes the connection pool is incompatible error which was raised while making a connection request to sql server.

According to the official documentation, the asyncio.Condition object should be handled using an async with construct instead of a with with an await expression as done in aiodbc.

<!-- Are there any issues opened that will be resolved by merging this change? -->
#294 