### PR TITLE
fix default value for cursor.fetchmany() parameter

### DIFF
--- a/aioodbc/cursor.py
+++ b/aioodbc/cursor.py
@@ -173,7 +173,7 @@ class Cursor:
         fut = self._run_operation(self._impl.fetchall)
         return fut
 
-    def fetchmany(self, size):
+    def fetchmany(self, size=0):
         """Returns a list of remaining rows, containing no more than size
         rows, used to process results in chunks. The list will be empty when
         there are no more rows.
@@ -187,6 +187,8 @@ class Cursor:
 
         :param size: int, max number of rows to return
         """
+        if not size:
+            size = self.arraysize
         fut = self._run_operation(self._impl.fetchmany, size)
         return fut
 


### PR DESCRIPTION
Add missing size = self.arraysize default value, as per spec and comments.

<!-- Thank you for your contribution! -->

## What do these changes do?

.fetchmany(size) should default the size parameter to cursor.arraysize if not supplied.  The comments in the source code say as much but it is missing.  This patch corrects this.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No changes, other than code that should have worked will now work as expected (rather than being syntactically incorrect.)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

https://github.com/aio-libs/aioodbc/issues/377

## Checklist

- [X ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ X] Documentation reflects the changes  - yes, no change required
- [ ] Add a new news fragment into the `CHANGES` folder 
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
