### PR TITLE
Update type annotations in pool.py

### DIFF
--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -194,7 +194,7 @@ class Pool:
                 self._free.append(conn)
             await self._wakeup()
 
-    async def __aenter__(self) -> "Pool":
+    async def __aenter__(self) -> Pool:
         return self
 
     async def __aexit__(
@@ -207,7 +207,7 @@ class Pool:
         await self.wait_closed()
 
 
-async def _destroy_pool(pool: "Pool") -> None:
+async def _destroy_pool(pool: Pool) -> None:
     pool.close()
     await pool.wait_closed()
 

--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -23,6 +23,7 @@ class Pool:
 
     def __init__(
         self,
+        dsn: str,
         minsize: int,
         maxsize: int,
         echo: bool,
@@ -39,6 +40,7 @@ class Pool:
             msg = "Explicit loop is deprecated, and has no effect."
             warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
+        self._dsn = dsn
         self._minsize = minsize
         self._maxsize = maxsize
         self._loop = asyncio.get_event_loop()
@@ -160,7 +162,7 @@ class Pool:
         while self.size < self.minsize:
             self._acquiring += 1
             try:
-                conn = await connect(echo=self._echo, **self._conn_kwargs)
+                conn = await connect(dsn=self._dsn, echo=self._echo, **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
@@ -172,7 +174,7 @@ class Pool:
         if override_min and self.size < self.maxsize:
             self._acquiring += 1
             try:
-                conn = await connect(echo=self._echo, **self._conn_kwargs)
+                conn = await connect(dsn=self._dsn, echo=self._echo, **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
@@ -213,6 +215,7 @@ async def _destroy_pool(pool: Pool) -> None:
 
 
 async def _create_pool(
+    dsn: str,
     minsize: int = 10,
     maxsize: int = 10,
     echo: bool = False,
@@ -220,6 +223,7 @@ async def _create_pool(
     **kwargs: Dict[Any, Any],
 ) -> Pool:
     pool = Pool(
+        dsn=dsn,
         minsize=minsize,
         maxsize=maxsize,
         echo=echo,
@@ -234,6 +238,7 @@ async def _create_pool(
 
 
 def create_pool(
+    dsn: str,
     minsize: int = 10,
     maxsize: int = 10,
     echo: bool = False,
@@ -247,6 +252,7 @@ def create_pool(
 
     return _ContextManager[Pool](
         _create_pool(
+            dsn=dsn,
             minsize=minsize,
             maxsize=maxsize,
             echo=echo,

--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -1,6 +1,8 @@
 # copied from aiopg
 # https://github.com/aio-libs/aiopg/blob/master/aiopg/pool.py
 
+from __future__ import annotations
+
 import asyncio
 import collections
 import warnings

--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -7,7 +7,7 @@ import asyncio
 import collections
 import warnings
 from types import TracebackType
-from typing import Any, Deque, Dict, Optional, Set, Type
+from typing import Any, Deque, Optional, Set, Type
 
 from pyodbc import ProgrammingError
 
@@ -29,7 +29,7 @@ class Pool:
         echo: bool,
         pool_recycle: int,
         loop: Optional[asyncio.AbstractEventLoop] = None,
-        **kwargs: Dict[Any, Any],
+        **kwargs: Any,
     ) -> None:
         if minsize < 0:
             raise ValueError("minsize should be zero or greater")
@@ -228,7 +228,7 @@ async def _create_pool(
     maxsize: int = 10,
     echo: bool = False,
     pool_recycle: int = -1,
-    **kwargs: Dict[Any, Any],
+    **kwargs: Any,
 ) -> Pool:
     pool = Pool(
         dsn=dsn,
@@ -252,7 +252,7 @@ def create_pool(
     echo: bool = False,
     loop: None = None,
     pool_recycle: int = -1,
-    **kwargs: Dict[Any, Any],
+    **kwargs: Any,
 ) -> _ContextManager[Pool]:
     if loop is not None:
         msg = "Explicit loop is deprecated, and has no effect."

--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -162,7 +162,11 @@ class Pool:
         while self.size < self.minsize:
             self._acquiring += 1
             try:
-                conn = await connect(dsn=self._dsn, echo=self._echo, **self._conn_kwargs)
+                conn = await connect(
+                    dsn=self._dsn,
+                    echo=self._echo,
+                    **self._conn_kwargs,
+                )
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
@@ -174,7 +178,11 @@ class Pool:
         if override_min and self.size < self.maxsize:
             self._acquiring += 1
             try:
-                conn = await connect(dsn=self._dsn, echo=self._echo, **self._conn_kwargs)
+                conn = await connect(
+                    dsn=self._dsn,
+                    echo=self._echo,
+                    **self._conn_kwargs,
+                )
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()


### PR DESCRIPTION
## What do these changes do?

- Added missing `dsn` kwarg to `create_pool()`, `_create_pool()`, and Pool's `__init__` method[^1]
- Updated forward ref'd types to use postponed evaluation[^2]

[^1]: https://github.com/aio-libs/aioodbc/pull/431#discussion_r1184518065
[^2]: https://peps.python.org/pep-0563/

## Are there changes in behavior for the user?

Users will notice that `dsn` is now a required keyword argument for `create_pool()` and Pool's `__init__` method. It was previously a required kwarg for normal operability with pooling but was not defined as such on either of the aforementioned callables.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
