### PR TITLE
Fix the linting job; dropping support for python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ aioodbc
     :alt: Chat on Gitter
 
 **aioodbc** is a Python 3.7+ module that enables access to ODBC_ databases
-with asyncio_. It relies on the pyodbc_ library and preserves its look and
+with asyncio_. It relies on the awesome pyodbc_ library and preserves its look and
 feel. Internally, *aioodbc* uses threads to avoid blocking the event loop.
 threads_ aren't as bad as you might think! Other drivers like motor_ use the
 same approach.
@@ -28,7 +28,7 @@ Basic Example
 -------------
 
 **aioodbc** is based on pyodbc_ and provides the same API. You just need
-to use ``await conn.f()`` instead of ``conn.f()``.
+to use ``yield from conn.f()`` or ``await conn.f()`` instead of ``conn.f()``.
 
 Properties are unchanged, so ``conn.prop`` is correct, as is
 ``conn.prop = val``.
@@ -120,12 +120,12 @@ Installation
 ------------
 
 In a Linux environment, pyodbc_ (hence *aioodbc*) requires the unixODBC_ library.
-You can install it using your package manager, for example:
+You can install it using your package manager, for example::
 
       $ sudo apt-get install unixodbc
       $ sudo apt-get install unixodbc-dev
 
-Then:
+Then::
 
    pip install aioodbc
 
@@ -133,7 +133,7 @@ Then:
 Run tests
 ---------
 
-To run tests locally without Docker, install `unixodbc` and the `sqlite` driver:
+To run tests locally without Docker, install `unixodbc` and the `sqlite` driver::
 
       $ sudo apt-get install unixodbc
       $ sudo apt-get install libsqliteodbc
@@ -142,7 +142,7 @@ Create a virtual environment and install the package with requirements:
 
       $ pip install -r requirements-dev.txt
 
-Run tests, linters, etc.:
+Run tests, linters, etc.::
 
       $ make fmt
       $ make lint

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 aioodbc
 =======
+
 .. image:: https://github.com/aio-libs/aioodbc/workflows/CI/badge.svg
    :target: https://github.com/aio-libs/aioodbc/actions?query=workflow%3ACI
    :alt: GitHub Actions status for master branch
@@ -13,23 +14,23 @@ aioodbc
     :target: https://gitter.im/aio-libs/Lobby
     :alt: Chat on Gitter
 
-**aioodbc** is a Python 3.7+ module that makes it possible to access ODBC_ databases
-with asyncio_. It relies on the awesome pyodbc_ library and preserves the same look and
-feel. Internally *aioodbc* employs threads to avoid blocking the event loop,
-threads_ are not that as bad as you think!. Other drivers like motor_ use the
+**aioodbc** is a Python 3.7+ module that enables access to ODBC_ databases
+with asyncio_. It relies on the pyodbc_ library and preserves its look and
+feel. Internally, *aioodbc* uses threads to avoid blocking the event loop.
+threads_ aren't as bad as you might think! Other drivers like motor_ use the
 same approach.
 
 **aioodbc** is fully compatible and tested with uvloop_. Take a look at the test
-suite, all tests are executed with both the default event loop and uvloop_.
+suite; all tests are executed with both the default event loop and uvloop_.
 
 
 Basic Example
 -------------
 
-**aioodbc** is based on pyodbc_ and provides the same api, you just need
-to use  ``yield from conn.f()`` or ``await conn.f()`` instead of ``conn.f()``
+**aioodbc** is based on pyodbc_ and provides the same API. You just need
+to use ``await conn.f()`` instead of ``conn.f()``.
 
-Properties are unchanged, so ``conn.prop`` is correct as well as
+Properties are unchanged, so ``conn.prop`` is correct, as is
 ``conn.prop = val``.
 
 
@@ -59,6 +60,7 @@ Properties are unchanged, so ``conn.prop`` is correct as well as
 
 Connection Pool
 ---------------
+
 Connection pooling is ported from aiopg_ and relies on PEP492_ features:
 
 .. code:: python
@@ -88,7 +90,8 @@ Connection pooling is ported from aiopg_ and relies on PEP492_ features:
 
 Context Managers
 ----------------
-`Pool`, `Connection` and `Cursor` objects support the context management
+
+`Pool`, `Connection`, and `Cursor` objects support the context management
 protocol:
 
 .. code:: python
@@ -116,29 +119,30 @@ protocol:
 Installation
 ------------
 
-In a linux environment pyodbc_ (hence *aioodbc*) requires the unixODBC_ library.
-You can install it using your package manager, for example::
+In a Linux environment, pyodbc_ (hence *aioodbc*) requires the unixODBC_ library.
+You can install it using your package manager, for example:
 
       $ sudo apt-get install unixodbc
       $ sudo apt-get install unixodbc-dev
 
-Then::
+Then:
 
    pip install aioodbc
 
 
 Run tests
 ---------
-To run tests locally without docker, install `unixodbc` and `sqlite` driver::
+
+To run tests locally without Docker, install `unixodbc` and the `sqlite` driver:
 
       $ sudo apt-get install unixodbc
       $ sudo apt-get install libsqliteodbc
 
-Create virtualenv and install package with requirements::
+Create a virtual environment and install the package with requirements:
 
       $ pip install -r requirements-dev.txt
 
-Run tests, lints etc::
+Run tests, linters, etc.:
 
       $ make fmt
       $ make lint
@@ -149,7 +153,7 @@ Other SQL Drivers
 -----------------
 
 * aiopg_ - asyncio client for PostgreSQL
-* aiomysql_ - asyncio client form MySQL
+* aiomysql_ - asyncio client for MySQL
 
 
 Requirements

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,27 +1,42 @@
-# NOTE: stretch was very crashy when using https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.16-linux-debian9-x86-64bit.tar.gz
-FROM python:3.6.8-slim-jessie
+FROM python:3.8-slim
 
 # configure apt to install minimal dependencies in non-interactive mode.
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf; \
     echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf
 
-RUN apt-get update && apt-get install -y \
-    unixODBC wget g++ unixodbc-dev odbc-postgresql libmyodbc libsqlite-dev libtool build-essential && \
-    odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini && \
-    wget http://archive.ubuntu.com/ubuntu/pool/universe/s/sqliteodbc/libsqliteodbc_0.9992-0.1_amd64.deb && \
-    dpkg -i libsqliteodbc_0.9992-0.1_amd64.deb
+# Update apt cache and install ODBC core, drivers, build tools, and Python essentials
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Core ODBC components
+    unixodbc \
+    unixodbc-dev \
+    # Build tools (needed for some pip installs or if compiling other things)
+    build-essential \
+    # ODBC Drivers
+    odbc-postgresql \
+    # MariaDB ODBC driver (works for MySQL)
+    odbc-mariadb \
+    libsqliteodbc \
+    # Utilities (if needed, e.g., for downloading other things)
+    wget \
+    curl \
+    git \
+    # -----------------------------------------------------------
+    # Clean up APT cache to reduce image size
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-ADD / /aioodbc
+ADD . /aioodbc
+RUN ls -la /aioodbc
+WORKDIR /aioodbc
+
 RUN pip install -e /aioodbc/ && \
     pip install -U pip setuptools && \
     pip install -r /aioodbc/requirements-dev.txt
 
 # with --squash option in docker build, this will reduce the final image size a bit.
 RUN rm -rf /aioodbc && \
-    rm libsqliteodbc_0.9992-0.1_amd64.deb && \
     apt-get purge -y g++ && \
     apt-get purge -y wget && \
     apt-get autoremove -y
 
-WORKDIR /aioodbc

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ADD . /aioodbc
-RUN ls -la /aioodbc
 WORKDIR /aioodbc
 
 RUN pip install -e /aioodbc/ && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # MariaDB ODBC driver (works for MySQL)
     odbc-mariadb \
     libsqliteodbc \
+    # ODBC Driver Manager
+    odbcinst \
     # Utilities (if needed, e.g., for downloading other things)
     wget \
     curl \
@@ -26,6 +28,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Update odbcinst.ini drivers are already installed, but MariaDB needs to be renamed to MySQL
+# RUN echo "[PostgreSQL Unicode]\nDescription = PostgreSQL ODBC driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so\nFileUsage = 1\n" >> /etc/odbcinst.ini
+RUN echo "[MySQL]\nDescription = MariaDB ODBC driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so\nFileUsage = 1\n" >> /etc/odbcinst.ini
+# RUN echo "[SQLite3]\nDescription = SQLite3 ODBC driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so\nFileUsage = 1\n" >> /etc/odbcinst.ini
+
 ADD . /aioodbc
 WORKDIR /aioodbc
 
@@ -34,8 +41,8 @@ RUN pip install -e /aioodbc/ && \
     pip install -r /aioodbc/requirements-dev.txt
 
 # with --squash option in docker build, this will reduce the final image size a bit.
-RUN rm -rf /aioodbc && \
-    apt-get purge -y g++ && \
-    apt-get purge -y wget && \
-    apt-get autoremove -y
+# RUN rm -rf /aioodbc && \
+#     apt-get purge -y g++ && \
+#     apt-get purge -y wget && \
+#     apt-get autoremove -y
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -41,8 +41,8 @@ RUN pip install -e /aioodbc/ && \
     pip install -r /aioodbc/requirements-dev.txt
 
 # with --squash option in docker build, this will reduce the final image size a bit.
-# RUN rm -rf /aioodbc && \
-#     apt-get purge -y g++ && \
-#     apt-get purge -y wget && \
-#     apt-get autoremove -y
+RUN rm -rf /aioodbc && \
+    apt-get purge -y g++ && \
+    apt-get purge -y wget && \
+    apt-get autoremove -y
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ black==23.3.0
 flake8-bugbear==23.3.23
 flake8==6.0.0
 ipdb==0.13.13
-ipython==8.13.2
+ipython==8.12.3
 isort==5.12.0
 mypy==1.2.0
 pyodbc==5.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,5 @@ pytest-sugar
 pytest==7.3.1
 sphinx==7.0.0
 sphinxcontrib-asyncio==0.3.0
-twine==4.0.2
+twine==6.1.0
 uvloop==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -50,7 +49,7 @@ setup(
     download_url="https://pypi.python.org/pypi/aioodbc",
     license="Apache 2",
     packages=find_packages(exclude=("tests",)),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     setup_requires=[
         "setuptools>=45",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The ci docker base image was outdated. This change upgrades from `python:3.6.8-slim-jessie` to `python:3.8-slim`.  

Why 3.8?  
Because the required install dependency (`pyodbc>=5.0.1`) only supports python>=3.8. [Reference](https://pypi.org/project/pyodbc/5.0.1/).  

Subsequently the `setup.py` had to be updated to drop support for 3.7.  

To fix the lint job, `twine` needed to be bumped from `4.0.2` to latest (`6.1.0`).
`ipython` needed to be bumped down from `8.13.2` to `8.12.3` because `8.13.2` supports from python>=3.9.

Minor tweaks to the `README.rst`

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Dropping support for python 3.7.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
