### PR TITLE
Adding Connection setencoding and setdecoding

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -127,6 +127,15 @@ async def test_rollback(conn):
 
 @pytest.mark.parametrize("db", pytest.db_list)
 @pytest.mark.asyncio
+async def test_setencoding_setdecoding(conn):
+    result = await conn.setencoding("utf-8")
+    assert result is None
+    result = await conn.setdecoding(pyodbc.SQL_CHAR, encoding="utf-8")
+    assert result is None
+
+
+@pytest.mark.parametrize("db", pytest.db_list)
+@pytest.mark.asyncio
 async def test_custom_executor(dsn, executor):
     conn = await aioodbc.connect(dsn=dsn, executor=executor)
     assert conn._executor is executor


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Pass through the pyodbc functions `setencoding` and `setdecoding` for a `Connection` object.

## Are there changes in behavior for the user?

Adding functionality
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
